### PR TITLE
fix: asm pause does not exist on Apple ARM

### DIFF
--- a/lzhamdecomp/lzham_core.h
+++ b/lzhamdecomp/lzham_core.h
@@ -150,15 +150,23 @@
    #elif (TARGET_OS_MAC == 1)
       #define LZHAM_PLATFORM_PC 1
 
-      #if defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__)
-         #define LZHAM_PLATFORM_PC_X64 1
-         #define LZHAM_64BIT_POINTERS 1
-         #define LZHAM_CPU_HAS_64BIT_REGISTERS 1
-      #else
-         #define LZHAM_PLATFORM_PC_X86 1
-         #define LZHAM_64BIT_POINTERS 0
-         #define LZHAM_CPU_HAS_64BIT_REGISTERS 0
-      #endif
+	#if defined(__arm64__) || defined(__aarch64__)
+		#define LZHAM_PLATFORM_PC_ARM64 1
+		#define LZHAM_64BIT_POINTERS 1
+		#define LZHAM_CPU_HAS_64BIT_REGISTERS 1
+	#elif defined(__arm__)
+		#define LZHAM_PLATFORM_PC_ARM32 1
+		#define LZHAM_64BIT_POINTERS 0
+		#define LZHAM_CPU_HAS_64BIT_REGISTERS 0
+	#elif defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__)
+		#define LZHAM_PLATFORM_PC_X64 1
+		#define LZHAM_64BIT_POINTERS 1
+		#define LZHAM_CPU_HAS_64BIT_REGISTERS 1
+	#else
+		#define LZHAM_PLATFORM_PC_X86 1
+		#define LZHAM_64BIT_POINTERS 0
+		#define LZHAM_CPU_HAS_64BIT_REGISTERS 0
+	#endif
 
       #define LZHAM_USE_UNALIGNED_INT_LOADS 1
 

--- a/lzhamdecomp/lzham_platform.h
+++ b/lzhamdecomp/lzham_platform.h
@@ -24,7 +24,13 @@ void lzham_fail(const char* pExp, const char* pFile, unsigned line);
 #if defined(__GNUC__) && LZHAM_PLATFORM_PC
 extern __inline__ __attribute__((__always_inline__,__gnu_inline__)) void lzham_yield_processor()
 {
-   __asm__ __volatile__("pause");
+	#if LZHAM_PLATFORM_PC_X64 || LZHAM_PLATFORM_PC_X86
+        __asm__ __volatile__("pause");
+    #elif LZHAM_PLATFORM_PC_ARM64 || LZHAM_PLATFORM_PC_ARM32
+		__asm__ __volatile__("yield");
+	#else
+		__asm__ __volatile__("rep; nop" : : : "memory");
+	#endif
 }
 #elif LZHAM_PLATFORM_X360
 #define lzham_yield_processor() \


### PR DESCRIPTION
Currently lzham devel fails to compile on Apple ARM, so I replaced asm "pause" with "yield" on arm machines, which works on anything past armv7

Critique welcome 🙂 